### PR TITLE
Handle empty cookie header

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const { parse } = require('cookie')
 
 module.exports = handler => (req, res) => {
   // Passes through req.cookies if there are already parsed cookies
-  const cookies = parse(req.headers.cookie)
+  const cookies = parse((req.headers && req.headers.cookie) || '')
 
   const newReq = Object.assign(req, { cookies })
 


### PR DESCRIPTION
When there is no cookie in the header the parse fail. This fix this issue